### PR TITLE
action_values

### DIFF
--- a/src/POMDPPolicies.jl
+++ b/src/POMDPPolicies.jl
@@ -11,14 +11,14 @@ using BeliefUpdaters
 using POMDPModelTools: ordered_actions
 
 """
-    action_values(p::Policy, s)
+    actionvalues(p::Policy, s)
 
 returns the values of each action at state s in a vector
 """
-function action_values end
+function actionvalues end
 
 export 
-    action_values
+    actionvalues
 
 export
     AlphaVectorPolicy

--- a/src/POMDPPolicies.jl
+++ b/src/POMDPPolicies.jl
@@ -10,6 +10,16 @@ import POMDPs: action, value, solve, updater
 using BeliefUpdaters
 using POMDPModelTools: ordered_actions
 
+"""
+    action_values(p::Policy, s)
+
+returns the values of each action at state s in a vector
+"""
+function action_values end
+
+export 
+    action_values
+
 export
     AlphaVectorPolicy
 

--- a/src/alpha_vector.jl
+++ b/src/alpha_vector.jl
@@ -63,6 +63,19 @@ function action(p::AlphaVectorPolicy, b::DiscreteBelief)
     return p.action_map[best_idx]
 end
 
+function action_values(p::AlphaVectorPolicy, b::DiscreteBelief)
+    num_vectors = length(p.alphas)
+    max_values = -Inf*ones(n_actions(p.pomdp))
+    for i = 1:num_vectors
+        temp_value = dot(b.b, p.alphas[i])
+        ai = actionindex(p.pomdp, p.action_map[i]) 
+        if temp_value > max_values[ai]
+            max_values[ai] = temp_value
+        end
+    end
+    return max_values
+end
+
 function Base.push!(p::AlphaVectorPolicy, alpha::Vector{Float64}, a)
     push!(p.alphas, alpha)
     push!(p.action_map, a)

--- a/src/alpha_vector.jl
+++ b/src/alpha_vector.jl
@@ -63,7 +63,7 @@ function action(p::AlphaVectorPolicy, b::DiscreteBelief)
     return p.action_map[best_idx]
 end
 
-function action_values(p::AlphaVectorPolicy, b::DiscreteBelief)
+function actionvalues(p::AlphaVectorPolicy, b::DiscreteBelief)
     num_vectors = length(p.alphas)
     max_values = -Inf*ones(n_actions(p.pomdp))
     for i = 1:num_vectors

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -56,3 +56,5 @@ function ValuePolicy(mdp::Union{MDP,POMDP}, value_table = zeros(n_states(mdp), n
 end
 
 action(p::ValuePolicy, s) = p.act[argmax(p.value_table[stateindex(p.mdp, s),:])]
+
+action_values(p::ValuePolicy, s) = p.value_table[stateindex(p.mdp, s), :]

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -35,6 +35,8 @@ end
 """
      ValuePolicy{P<:Union{POMDP,MDP}, T<:AbstractMatrix{Float64}, A}
 A generic MDP policy that consists of a value table. The entry at `stateindex(mdp, s)` is the action that will be taken in state `s`.
+It is expected that the order of the actions in the value table is consistent with the order of the actions in `act`. 
+If `act` is not explicitly set in the construction, `act` is ordered according to `actionindex`.
 
 # Fields 
 - `mdp::P` the MDP problem

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -15,7 +15,6 @@ mutable struct VectorPolicy{S,A} <: Policy
 end
 
 action(p::VectorPolicy, s) = p.act[stateindex(p.mdp, s)]
-action(p::VectorPolicy, s, a) = action(p, s)
 
 """
     VectorSolver{A}
@@ -42,17 +41,13 @@ A generic MDP policy that consists of a value table. The entry at `stateindex(md
 - `value_table::T` the value table as a |S|x|A| matrix
 - `act::Vector{A}` the possible actions
 """
-mutable struct ValuePolicy{P<:Union{POMDP,MDP}, T<:AbstractMatrix{Float64}, A} <: Policy
+struct ValuePolicy{P<:Union{POMDP,MDP}, T<:AbstractMatrix{Float64}, A} <: Policy
     mdp::P
     value_table::T
     act::Vector{A}
 end
 function ValuePolicy(mdp::Union{MDP,POMDP}, value_table = zeros(n_states(mdp), n_actions(mdp)))
-    acts = Any[]
-    for a in actions(mdp)
-        push!(acts, a)
-    end
-    return ValuePolicy(mdp, value_table, acts)
+    return ValuePolicy(mdp, value_table, ordered_actions(mdp))
 end
 
 action(p::ValuePolicy, s) = p.act[argmax(p.value_table[stateindex(p.mdp, s),:])]

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -57,4 +57,4 @@ end
 
 action(p::ValuePolicy, s) = p.act[argmax(p.value_table[stateindex(p.mdp, s),:])]
 
-action_values(p::ValuePolicy, s) = p.value_table[stateindex(p.mdp, s), :]
+actionvalues(p::ValuePolicy, s) = p.value_table[stateindex(p.mdp, s), :]

--- a/test/test_alpha_policy.jl
+++ b/test/test_alpha_policy.jl
@@ -12,10 +12,11 @@ let
     # initial belief is 100% confidence in baby not being hungry
     @test isapprox(value(policy, b0), -16.0629)
     @test isapprox(value(policy, [1.0,0.0]), -16.0629)
-
+    @test isapprox(action_values(policy, b0), [-16.0629, -19.4557])
+    
     # because baby isn't hungry, policy should not feed (return false)
     @test action(policy, b0) == false
-
+     
     # try pushing new vector
     push!(policy, [0.0,0.0], true)
 

--- a/test/test_alpha_policy.jl
+++ b/test/test_alpha_policy.jl
@@ -12,7 +12,7 @@ let
     # initial belief is 100% confidence in baby not being hungry
     @test isapprox(value(policy, b0), -16.0629)
     @test isapprox(value(policy, [1.0,0.0]), -16.0629)
-    @test isapprox(action_values(policy, b0), [-16.0629, -19.4557])
+    @test isapprox(actionvalues(policy, b0), [-16.0629, -19.4557])
     
     # because baby isn't hungry, policy should not feed (return false)
     @test action(policy, b0) == false

--- a/test/test_vector_policy.jl
+++ b/test/test_vector_policy.jl
@@ -15,4 +15,9 @@ let
     for s2 in states(gw)
         @test action(p2, s2) == GridWorldAction(:left)
     end
+
+    p3 = ValuePolicy(gw)
+    for s2 in states(gw)
+        @inferred(action(p3, s2)) isa GridWorldAction
+    end
 end


### PR DESCRIPTION
This PR implements the `action_values` function.

This function is added to the interface by POMDPPolicies. Two default implementations are provided for `AlphaVectorPolicy` and `ValuePolicy`. 

It addresses an old issue: JuliaPOMDP/POMDPToolbox.jl#73