### PR TITLE
AlphaVectorPolicy with SparseCat beliefs

### DIFF
--- a/src/POMDPPolicies.jl
+++ b/src/POMDPPolicies.jl
@@ -8,7 +8,7 @@ using POMDPs
 import POMDPs: action, value, solve, updater
 
 using BeliefUpdaters
-using POMDPModelTools: ordered_actions
+using POMDPModelTools
 
 """
     actionvalues(p::Policy, s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using POMDPPolicies
 using POMDPs
 using BeliefUpdaters
 using POMDPSimulators
+using POMDPModelTools
 using POMDPModels
 using Random
 

--- a/test/test_alpha_policy.jl
+++ b/test/test_alpha_policy.jl
@@ -13,9 +13,16 @@ let
     @test isapprox(value(policy, b0), -16.0629)
     @test isapprox(value(policy, [1.0,0.0]), -16.0629)
     @test isapprox(actionvalues(policy, b0), [-16.0629, -19.4557])
-    
+   
     # because baby isn't hungry, policy should not feed (return false)
     @test action(policy, b0) == false
+
+    # SparseCat belief
+    sparse_b0 = SparseCat([s for s in ordered_states(pomdp) if pdf(b0, s) != 0.],
+                        b0.b[b0.b .> 0.])
+    @test isapprox(value(policy, sparse_b0), -16.0629)
+    @test isapprox(actionvalues(policy, sparse_b0), [-16.0629, -19.4557])
+    @test action(policy, sparse_b0) == false
      
     # try pushing new vector
     push!(policy, [0.0,0.0], true)


### PR DESCRIPTION
implement `action(::AlphaVectorPolicy, ::SparseCat)`, `actionvalues`, and `value`.

A more elegant solution could have been to implement a new method for `dot` since it is the only difference between `DiscreteBelief` and `SparseCat` but I needed an extra `pomdp` argument to make the dot product between the alpha vector and the sparse categorical belief to retrieve states indices.