### PR TITLE
deprecated AlphaVectorPolicy(m, alphas)

### DIFF
--- a/src/alpha_vector.jl
+++ b/src/alpha_vector.jl
@@ -24,9 +24,7 @@ struct AlphaVectorPolicy{P<:POMDP, A} <: Policy
     action_map::Vector{A}
 end
 
-function AlphaVectorPolicy(pomdp::POMDP, alphas)
-    AlphaVectorPolicy(pomdp, alphas, ordered_actions(pomdp))
-end
+@deprecate AlphaVectorPolicy(pomdp::POMDP, alphas) AlphaVectorPolicy(pomdp, alphas, ordered_actions(pomdp))
 
 # assumes alphas is |S| x (number of alpha vecs)
 function AlphaVectorPolicy(p::POMDP, alphas::Matrix{Float64}, action_map)

--- a/test/test_alpha_policy.jl
+++ b/test/test_alpha_policy.jl
@@ -7,7 +7,7 @@ let
     # these values were gotten from FIB.jl
     # alphas = [-29.4557 -36.5093; -19.4557 -16.0629]
     alphas = [ -16.0629 -19.4557; -36.5093 -29.4557]
-    policy = AlphaVectorPolicy(pomdp, alphas)
+    policy = AlphaVectorPolicy(pomdp, alphas, ordered_actions(pomdp))
 
     @test Set(alphapairs(policy)) == Set([[-16.0629, -36.5093]=>false, [-19.4557, -29.4557]=>true])
     @test Set(alphavectors(policy)) == Set([[-16.0629, -36.5093], [-19.4557, -29.4557]])


### PR DESCRIPTION
The `AlphaVectorPolicy(m, alphas)` constructor seems really dangerous to me - it seems very easy to accidentally make alpha vectors match up with the wrong actions.

Is it ok if I deprecate it in favor of `AlphaVectorPolicy(m, alphas, action_map)` so that people explicitly have to specify which actions the alpha vectors correspond to?

I'll go back and make sure no solvers use the two argument one if we accept this.