### PR TITLE
Added PlaybackPolicy type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 
 [compat]
 BeliefUpdaters = "0.1, 0.2"

--- a/docs/src/playback.md
+++ b/docs/src/playback.md
@@ -1,0 +1,11 @@
+# Playback Policy
+
+A policy that replays a fixed sequence of actions. When all actions are used, a backup policy is used.
+
+```@docs
+PlaybackPolicy
+```
+
+```@docs
+PlaybackPolicy
+```

--- a/src/POMDPPolicies.jl
+++ b/src/POMDPPolicies.jl
@@ -5,6 +5,7 @@ using Random
 using StatsBase # for Weights
 using SparseArrays # for sparse vectors in alpha_vector.jl
 using Parameters
+using Distributions # For logpdf extenstion in playback policy
 
 using POMDPs
 import POMDPs: action, value, solve, updater
@@ -21,7 +22,7 @@ returns the values of each action at state s in a vector
 """
 function actionvalues end
 
-export 
+export
     actionvalues
 
 export
@@ -57,7 +58,7 @@ export
 
 include("stochastic.jl")
 
-export LinearDecaySchedule, 
+export LinearDecaySchedule,
        EpsGreedyPolicy,
        SoftmaxPolicy,
        ExplorationPolicy,
@@ -76,5 +77,9 @@ export
 
 include("pretty_printing.jl")
 
+export
+    PlaybackPolicy
+
+include("playback.jl")
 
 end

--- a/src/playback.jl
+++ b/src/playback.jl
@@ -1,0 +1,45 @@
+
+"""
+    RandomPolicy{RNG<:AbstractRNG, P<:Union{POMDP,MDP}, U<:Updater}
+a generic policy that uses the actions function to create a list of actions and then randomly samples an action from it.
+
+Constructor:
+
+    `PlaybackPolicy(actions::Vector{A}, backup_policy::Policy; logpdfs::Vector{Float64} = [])`
+
+# Fields
+- `actions::Vector{A}` a vector of actions to play back
+- `backup_policy::Policy` the policy to use when all prescribed actions have been taken but the episode continues
+- `logpdfs::Vector{Float64}` the log probability (density) of actions
+- `i::Int64` the current action index
+"""
+mutable struct PlaybackPolicy{A} <: Policy
+    actions::Vector{A}
+    backup_policy::Policy
+    logpdfs::Vector{Float64}
+    i::Int64
+end
+
+# Constructor for the PlaybackPolicy
+PlaybackPolicy(actions::Vector{A}, backup_policy::Policy; logpdfs::Vector{Float64} = Float64[]) where {A} = PlaybackPolicy(actions, backup_policy, logpdfs, 1)
+
+# Action selection for the PlaybackPolicy
+function POMDPs.action(p::PlaybackPolicy, s)
+    a = p.i <= length(p.actions) ? p.actions[p.i] : action(p.backup_policy, s)
+    p.i += 1
+    a
+end
+
+# Get the logpdf of the history from the playback policy and the backup policy
+function Distributions.logpdf(p::PlaybackPolicy, h)
+    N = min(length(p.actions), length(h))
+    # @assert all(collect(action_hist(h))[1:N] .== p.actions[1:N])
+    @assert length(p.actions) == length(p.logpdfs)
+    if length(h) > N
+        return sum(p.logpdfs) + sum(logpdf(p.backup_policy, view(h, N+1:length(h))))
+    else
+        return sum(p.logpdfs[1:N])
+    end
+end
+
+

--- a/src/playback.jl
+++ b/src/playback.jl
@@ -1,7 +1,7 @@
 
 """
-    PlaybackPolicy{A, P<:Policy}
-a generic policy that uses a fixed sequence of actions until they are all used and then falls back onto a backup policy until the end of the episode
+    PlaybackPolicy{A<:AbstractArray, P<:Policy, V<:AbstractArray{<:Real}}
+a policy that applies a fixed sequence of actions until they are all used and then falls back onto a backup policy until the end of the episode.
 
 Constructor:
 
@@ -13,10 +13,10 @@ Constructor:
 - `logpdfs::Vector{Float64}` the log probability (density) of actions
 - `i::Int64` the current action index
 """
-mutable struct PlaybackPolicy{A, P<:Policy, V<:Real} <: Policy
-    actions::AbstractArray{A}
+mutable struct PlaybackPolicy{A<:AbstractArray, P<:Policy, V<:AbstractArray{<:Real}} <: Policy
+    actions::A
     backup_policy::P
-    logpdfs::AbstractArray{V}
+    logpdfs::V
     i::Int64
 end
 

--- a/src/playback.jl
+++ b/src/playback.jl
@@ -1,11 +1,11 @@
 
 """
-    RandomPolicy{RNG<:AbstractRNG, P<:Union{POMDP,MDP}, U<:Updater}
-a generic policy that uses the actions function to create a list of actions and then randomly samples an action from it.
+    PlaybackPolicy{A, P<:Policy}
+a generic policy that uses a fixed sequence of actions until they are all used and then falls back onto a backup policy until the end of the episode
 
 Constructor:
 
-    `PlaybackPolicy(actions::Vector{A}, backup_policy::Policy; logpdfs::Vector{Float64} = [])`
+    `PlaybackPolicy(actions::AbstractArray, backup_policy::Policy; logpdfs::AbstractArray{Float64, 1} = Float64[])`
 
 # Fields
 - `actions::Vector{A}` a vector of actions to play back
@@ -13,15 +13,15 @@ Constructor:
 - `logpdfs::Vector{Float64}` the log probability (density) of actions
 - `i::Int64` the current action index
 """
-mutable struct PlaybackPolicy{A} <: Policy
-    actions::Vector{A}
-    backup_policy::Policy
-    logpdfs::Vector{Float64}
+mutable struct PlaybackPolicy{A, P<:Policy, V<:Real} <: Policy
+    actions::AbstractArray{A}
+    backup_policy::P
+    logpdfs::AbstractArray{V}
     i::Int64
 end
 
 # Constructor for the PlaybackPolicy
-PlaybackPolicy(actions::Vector{A}, backup_policy::Policy; logpdfs::Vector{Float64} = Float64[]) where {A} = PlaybackPolicy(actions, backup_policy, logpdfs, 1)
+PlaybackPolicy(actions::AbstractArray, backup_policy::Policy; logpdfs::AbstractArray{<:Real} = Float64[]) = PlaybackPolicy(actions, backup_policy, logpdfs, 1)
 
 # Action selection for the PlaybackPolicy
 function POMDPs.action(p::PlaybackPolicy, s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,9 @@ end
 @testset "pretty_printing" begin
     include("test_pretty_printing.jl")
 end
-@testset "exploration policies" begin 
+@testset "exploration policies" begin
     include("test_exploration_policies.jl")
+end
+@testset "playback policies" begin
+    include("test_playback_policy.jl")
 end

--- a/test/test_playback_policy.jl
+++ b/test/test_playback_policy.jl
@@ -1,0 +1,24 @@
+using Distributions
+
+mdp = SimpleGridWorld(tprob = 1)
+hist = simulate(HistoryRecorder(), mdp, RandomPolicy(mdp), GWPos(3,3))
+
+## Test the playback simulator
+playback = PlaybackPolicy(collect(action_hist(hist)), RandomPolicy(mdp))
+@test all(playback.actions .== action_hist(hist))
+@test playback.backup_policy isa RandomPolicy
+@test playback.i == 1
+@test_throws AssertionError logpdf(playback, hist)
+
+hist2 = simulate(HistoryRecorder(), mdp, playback, GWPos(3,3))
+@test hist == hist2
+
+## Test log probability
+Distributions.logpdf(p::RandomPolicy, h) = length(h)*log(1. / length(actions(p.problem)))
+playback = PlaybackPolicy(collect(action_hist(hist)), RandomPolicy(mdp), logpdfs = -ones(length(hist)))
+hist2 = simulate(HistoryRecorder(), mdp, playback, GWPos(3,3))
+@test logpdf(playback, hist2) == -1*length(hist2)
+
+playback = PlaybackPolicy([], RandomPolicy(mdp))
+@test logpdf(playback, hist2) == length(hist2)*log(0.25)
+


### PR DESCRIPTION
The PlaybackPolicy type allows for the replay of a fixed sequence of actions on an MDP or POMDP. Users must also specify a backup policy that is used if the episode is still going after the fixed sequence of actions is applied. 

