### PR TITLE
Relax Distributions requirements to 0.17-0.23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 BeliefUpdaters = "0.1, 0.2"
-Distributions = "0.23"
+Distributions = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
 POMDPModelTools = "0.2, 0.3"
 POMDPs = "0.7.3, 0.8, 0.9"
 Parameters = "0.12"


### PR DESCRIPTION
Back at it again—this one was super tricky! Long story short: Zygote, Flux, FilledArrays, CrossEntropyMethod, and MCTS all raised "unsatisfiable requirements" that ultimately led to POMDPPolicies strict Distributions requirement. Relaxing this seems to work well.

If you merge this, could you bump POMDPPolicies to v0.4.1? 